### PR TITLE
Set up dry run env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the staff who initiated the update. (Success / failure)
 ## Usage
 
 1.  `ruby consume_messages.rb`
-2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to false, it will run the script without updating the barcodes.
+2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to false, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to true, it will run the script without updating the barcodes.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ the staff who initiated the update. (Success / failure)
 ## Usage
 
 1.  `ruby consume_messages.rb`
+2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML to the assigned ReCap environment. If set to false, it will run the script without update the barcodes.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the staff who initiated the update. (Success / failure)
 ## Usage
 
 1.  `ruby consume_messages.rb`
-2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to false, it will run the script without update the barcodes.
+2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to false, it will run the script without updating the barcodes.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the staff who initiated the update. (Success / failure)
 ## Usage
 
 1.  `ruby consume_messages.rb`
-2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML to the assigned ReCap environment. If set to false, it will run the script without update the barcodes.
+2.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to true, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to false, it will run the script without update the barcodes.
 
 ## Deploying
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -9,3 +9,4 @@ NYPL_OAUTH_KEY=your_oauth_key
 NYPL_OAUTH_URL=https://example.com/
 NYPL_OAUTH_SECRET=a-long-secret
 PLATFORM_API_URL=https://example.org
+IS_DRY_RUN=false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,3 +9,4 @@ nypl_oauth_key: <%= ENV['NYPL_OAUTH_KEY'] %>
 nypl_oauth_url: <%= ENV['NYPL_OAUTH_URL'] %>
 nypl_oauth_secret: <%= ENV['NYPL_OAUTH_SECRET'] %>
 platform_api_url: <%= ENV['PLATFORM_API_URL'] %>
+is_dry_run: <%= ENV['IS_DRY_RUN'] %>

--- a/lib/message_handler.rb
+++ b/lib/message_handler.rb
@@ -38,6 +38,7 @@ class MessageHandler
             api_url: @settings['scsb_api_url'],
             api_key: @settings['scsb_api_key'],
             is_gcd_protected: false,
+            is_dry_run: @settings['is_dry_run'],
         )
 
         submit_collection_updater.update_scsb_items

--- a/lib/submit_collection_updater.rb
+++ b/lib/submit_collection_updater.rb
@@ -26,6 +26,7 @@ class SubmitCollectionUpdater
       puts "Updating the following #{@barcode_to_scsb_xml_mapping.keys.length} barcodes: #{@barcode_to_scsb_xml_mapping.keys.join(',')}"
       @barcode_to_scsb_xml_mapping.each do |barcode, scsb_xml|
         update_item(barcode, scsb_xml)
+      end
     end
   end
 

--- a/lib/submit_collection_updater.rb
+++ b/lib/submit_collection_updater.rb
@@ -15,13 +15,17 @@ class SubmitCollectionUpdater
     @api_url  = options[:api_url]
     @api_key = options[:api_key]
     @is_gcd_protected = options[:is_gcd_protected] || false
+    @is_dry_run = options[:is_dry_run]
   end
 
   # TODO: build up some kind of errors collection
   def update_scsb_items
-    puts "Updating the following #{@barcode_to_scsb_xml_mapping.keys.length} barcodes: #{@barcode_to_scsb_xml_mapping.keys.join(',')}"
-    @barcode_to_scsb_xml_mapping.each do |barcode, scsb_xml|
-      update_item(barcode, scsb_xml)
+    if (@is_dry_run)
+      puts "This is a dry run for development. It will not update any SCSB collection item."
+    else
+      puts "Updating the following #{@barcode_to_scsb_xml_mapping.keys.length} barcodes: #{@barcode_to_scsb_xml_mapping.keys.join(',')}"
+      @barcode_to_scsb_xml_mapping.each do |barcode, scsb_xml|
+        update_item(barcode, scsb_xml)
     end
   end
 


### PR DESCRIPTION
This PR is to add an environment variable of `IS_DRY_RUN` to prevent the script updating the barcodes to ReCap by accident.