### PR TITLE
BarcodeToCustomerCodeMapper can report .errors()

### DIFF
--- a/lib/barcode_to_customer_code_mapper.rb
+++ b/lib/barcode_to_customer_code_mapper.rb
@@ -1,9 +1,9 @@
 require 'httparty'
 require 'json'
+require 'errorable'
 
 class BarcodeToCustomerCodeMapper
-
-  attr_reader :errors
+  include Errorable
 
   def initialize(options)
     @errors   = {}
@@ -74,14 +74,6 @@ private
       fieldValue: barcode.to_s
     }
     JSON.generate(body)
-  end
-
-  def add_or_append_to_errors(barcode, message)
-    if @errors[barcode]
-      @errors[barcode] << message
-    else
-      @errors[barcode] = [message]
-    end
   end
 
 end

--- a/lib/barcode_to_customer_code_mapper.rb
+++ b/lib/barcode_to_customer_code_mapper.rb
@@ -3,7 +3,10 @@ require 'json'
 
 class BarcodeToCustomerCodeMapper
 
+  attr_reader :errors
+
   def initialize(options)
+    @errors   = {}
     @barcodes = options[:barcodes]
     @api_url  = options[:api_url]
     @api_key  = options[:api_key]
@@ -12,28 +15,43 @@ class BarcodeToCustomerCodeMapper
   def barcode_to_customer_code_mapping
     initial_results = {}
     @barcodes.each {|barcode| initial_results[barcode.to_s] = nil }
-    find_all_barcodes(@barcodes, {page_number: 0}, initial_results)
+
+    results = find_all_barcodes(@barcodes, {page_number: 0}, initial_results)
+
+    # Add requested, but unfound barcodes to errors hash
+    results.find_all {|barcode, customer_code| customer_code.nil? }.each do |barcode, customer_code|
+      add_or_append_to_errors(barcode, "Could not found in SCSB's search API")
+    end
+
+    results
   end
 
 private
 
   def find_all_barcodes(barcodes, options = {}, result = {})
-    response = HTTParty.post("#{@api_url}/searchService/search", headers: auth_headers, body: barcode_request_body(barcodes.join(','), options[:page_number]))
-    parsed_body = JSON.parse(response.body)
-    parsed_body['searchResultRows'].each do |result_row|
-      # guard against the off-chance SCSB returns barcode that wasn't requested
-      if @barcodes.include? result_row['barcode']
-        result[result_row['barcode']] = result_row['customerCode']
+    begin
+      response = HTTParty.post("#{@api_url}/searchService/search", headers: auth_headers, body: barcode_request_body(barcodes.join(','), options[:page_number]))
+      parsed_body = JSON.parse(response.body)
+
+      parsed_body['searchResultRows'].each do |result_row|
+        # guard against the off-chance SCSB returns barcode that wasn't requested
+        if @barcodes.include? result_row['barcode']
+          result[result_row['barcode']] = result_row['customerCode']
+        end
+      end
+
+      # parsed_body['totalPageCount']-1 because SCSB's pageSize params seems to be 0-indexed
+      if options[:page_number] == parsed_body['totalPageCount']-1 || parsed_body['totalPageCount'] == 0
+        return result
+      else
+        find_all_barcodes(@barcodes, {page_number: options[:page_number] + 1}, result)
+      end
+
+    rescue Exception => e
+      barcodes.each do |barcode|
+        add_or_append_to_errors(barcode, "Bad response from SCSB API")
       end
     end
-
-    # parsed_body['totalPageCount']-1 because SCSB's pageSize params seems to be 0-indexed
-    if options[:page_number] == parsed_body['totalPageCount']-1 || parsed_body['totalPageCount'] == 0
-      return result
-    else
-      find_all_barcodes(@barcodes, {page_number: options[:page_number] + 1}, result)
-    end
-
   end
 
   def auth_headers
@@ -57,4 +75,13 @@ private
     }
     JSON.generate(body)
   end
+
+  def add_or_append_to_errors(barcode, message)
+    if @errors[barcode]
+      @errors[barcode] << message
+    else
+      @errors[barcode] = [message]
+    end
+  end
+
 end

--- a/lib/errorable.rb
+++ b/lib/errorable.rb
@@ -1,5 +1,5 @@
-# A module used to for classes that, in their duty may generate errors that we want to
-# report to users. For example, an instance of BarcodeToCustomerCodeMapper may
+# A module used to for classes that, when performing their duty, can generate errors that
+# users should know about. For example, an instance of BarcodeToCustomerCodeMapper may
 # fail to connect to or get an unexpected response from a server.
 #
 # To use it `include Errorable` and make sure the constuctor initializes `@errors = {}`

--- a/lib/errorable.rb
+++ b/lib/errorable.rb
@@ -1,0 +1,17 @@
+module Errorable
+
+  def self.included(base)
+    attr_reader :errors
+  end
+
+protected
+
+  def add_or_append_to_errors(barcode, message)
+    if @errors[barcode]
+      @errors[barcode] << message
+    else
+      @errors[barcode] = [message]
+    end
+  end
+
+end

--- a/lib/errorable.rb
+++ b/lib/errorable.rb
@@ -1,3 +1,10 @@
+# A module used to for classes that, in their duty may generate errors that we want to
+# report to users. For example, an instance of BarcodeToCustomerCodeMapper may
+# fail to connect to or get an unexpected response from a server.
+#
+# To use it `include Errorable` and make sure the constuctor initializes `@errors = {}`
+# .errors() returns a hash where the key is (usually) a barcode and the value is an
+# Array of Strings
 module Errorable
 
   def self.included(base)

--- a/lib/errorable.rb
+++ b/lib/errorable.rb
@@ -11,7 +11,7 @@ module Errorable
     attr_reader :errors
   end
 
-protected
+  private
 
   def add_or_append_to_errors(barcode, message)
     if @errors[barcode]

--- a/spec/barcode_to_customer_code_mapper_spec.rb
+++ b/spec/barcode_to_customer_code_mapper_spec.rb
@@ -1,6 +1,36 @@
 require 'spec_helper'
 
 describe BarcodeToCustomerCodeMapper do
+
+  describe "errors()" do
+
+    before do
+      @barcode_mapper = BarcodeToCustomerCodeMapper.new(barcodes: ['1234', '5678'])
+    end
+
+    it "returns an empty hash before barcode_to_customer_code_mapping is called" do
+      expect(@barcode_mapper.errors).to eq({})
+    end
+
+    it "contains an error if there's an error with the connection to searchService" do
+      expect(HTTParty).to receive(:post).at_least(:once).and_return("This is nonsense")
+      @barcode_mapper.barcode_to_customer_code_mapping
+      error_message = 'Bad response from SCSB API'
+      expect(@barcode_mapper.errors['1234']).to include(error_message)
+      expect(@barcode_mapper.errors['5678']).to include(error_message)
+    end
+
+    it "contains an error if searchService can't find a barcode" do
+      fake_scsb_response = double()
+      allow(fake_scsb_response).to receive(:body) { JSON.generate({searchResultRows: [{barcode: '1234', customerCode: 'NA'}], totalPageCount: 1}) }
+      expect(HTTParty).to receive(:post).at_least(:once).and_return(fake_scsb_response)
+
+      @barcode_mapper.barcode_to_customer_code_mapping
+      expect(@barcode_mapper.errors).to eq({'5678' => ["Could not found in SCSB's search API"]})
+    end
+
+  end
+
   describe "barcode_to_customer_code_mapping" do
 
     it "can map an array of barcodes to a hash of barcodes => customer_code" do

--- a/spec/message_handler_spec.rb
+++ b/spec/message_handler_spec.rb
@@ -15,7 +15,7 @@ describe MessageHandler do
   it "will log a 'young' message but not try to process it" do
     fake_message = double(:body => JSON.generate({}), message_attributes: {}, :attributes => {"SentTimestamp" => Time.now.to_i.to_s})
     message_handler = MessageHandler.new({message: fake_message, settings: {'minimum_message_age_seconds' => "300"}})
-    NyplLogFormatter.any_instance.should_receive(:debug).with("Message '{}' is not old enough to process. It can be processed in 300 seconds")
+    expect_any_instance_of(NyplLogFormatter).to receive(:debug).with("Message '{}' is not old enough to process. It can be processed in 300 seconds")
     message_handler.handle
   end
 
@@ -29,7 +29,7 @@ describe MessageHandler do
     it "will log an error & delete the message" do
       fake_sqs_client = double(:delete_message)
       message_handler = MessageHandler.new({sqs_client: fake_sqs_client, message: @fake_message, settings: {'sqs_queue_url' => 'http://example.com', 'minimum_message_age_seconds' => "300"}})
-      NyplLogFormatter.any_instance.should_receive(:error).with("Message '{\"action\":\"iamsupported\"}' contains an unsupported action")
+      expect_any_instance_of(NyplLogFormatter).to receive(:error).with("Message '{\"action\":\"iamsupported\"}' contains an unsupported action")
       expect(fake_sqs_client).to receive(:delete_message).with(queue_url: 'http://example.com', receipt_handle: "some-id")
 
       message_handler.handle


### PR DESCRIPTION
Hey @ktp242 

This introduces the `Errorable` module.
See it's top-level comment for how to use it.

It's a module that gives common functionality to all our classes to build up
a common data structure of errors that looks like:

```ruby
{"barcode" => ['array', 'of', 'error messages'], 'anotherbarcode' => ['more', 'errors']}
```
This will allow us to aggregare all the .errors() from our helper objects to decide whether
or not to email users.

CCing: @holingpoon & @thisisstephenbetts  because they may be interested.
