### PR TITLE
Ktp/gather errors from scsbxml fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config/.env
+.rubocop.yml
+.rubocop_todo.yml

--- a/lib/barcode_to_customer_code_mapper.rb
+++ b/lib/barcode_to_customer_code_mapper.rb
@@ -1,6 +1,6 @@
 require 'httparty'
 require 'json'
-require 'errorable'
+require './lib/errorable'
 
 class BarcodeToCustomerCodeMapper
   include Errorable

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -3,7 +3,6 @@ require 'httparty'
 require 'nypl_log_formatter'
 
 class SCSBXMLFetcher
-
   # options is a hash used to instantiate a SCSBXMLFetcher
   #  options token [String]
   #  options oauth_url [String]
@@ -28,12 +27,17 @@ class SCSBXMLFetcher
     results = {}
     @barcode_to_customer_code_mapping.each do |barcode, customer_code|
       if customer_code
-        results[barcode] = HTTParty.get("#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
-            query: {customerCode: customer_code, barcode: barcode, includeFullBibTree: 'false'},
-            headers: {"Authorization" =>  "Bearer #{@oauth_token}"}
-          ).body
+        results[barcode] = HTTParty.get(
+          "#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
+          query: {
+            customerCode: customer_code,
+            barcode: barcode,
+            includeFullBibTree: 'false'
+          },
+          headers: { 'Authorization' => "Bearer #{@oauth_token}" }
+        ).body
       else
-        @logger.error("Not valid customer code for the barcode: #{barcode}." )
+        @logger.error("Not valid customer code for the barcode: #{barcode}.")
       end
     end
 
@@ -41,10 +45,10 @@ class SCSBXMLFetcher
   end
 
 private
+
   # TODO: We should cache tokens and retry once they expire
   def set_token
     client = OAuth2::Client.new(@oauth_key, @oauth_secret, site: @oauth_url)
     @oauth_token = client.client_credentials.get_token.token
   end
-
 end

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -16,6 +16,7 @@ class SCSBXMLFetcher
   #    This is the output of BarcodeToCustomerCodeMapper#barcode_to_customer_code_mapping
   def initialize(options = {})
     @token = nil
+    @errors = {}
     @oauth_url = options[:oauth_url]
     @oauth_key = options[:oauth_key]
     @oauth_secret = options[:oauth_secret]
@@ -45,7 +46,7 @@ class SCSBXMLFetcher
         end
       else
         @logger.error("Not valid customer code for the barcode: #{barcode}.")
-        add_or_append_to_errors(barcode, "No valid customer code")
+        add_or_append_to_errors(barcode, "Not have valid customer code")
       end
     end
 

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -1,10 +1,10 @@
 require 'oauth2'
 require 'httparty'
 require 'nypl_log_formatter'
-# require 'errorable'
+require './lib/errorable'
 
 class SCSBXMLFetcher
-  # include Errorable
+  include Errorable
 
   # options is a hash used to instantiate a SCSBXMLFetcher
   #  options token [String]
@@ -30,24 +30,22 @@ class SCSBXMLFetcher
     results = {}
     @barcode_to_customer_code_mapping.each do |barcode, customer_code|
       if customer_code
-        # begin
-        results[barcode] = HTTParty.get(
-          "#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
-          query: {
-            customerCode: customer_code,
-            barcode: barcode,
-            includeFullBibTree: 'false'
-          },
-          headers: { 'Authorization' => "Bearer #{@oauth_token}" }
-        ).body
-        # rescue Exception => e
-          # barcodes.each do |barcode|
-          #   add_or_append_to_errors(barcode, "Bad response from SCSB API")
-          # end
-          
-        # end
+        begin
+          results[barcode] = HTTParty.get(
+            "#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
+            query: {
+              customerCode: customer_code,
+              barcode: barcode,
+              includeFullBibTree: 'false'
+            },
+            headers: { 'Authorization' => "Bearer #{@oauth_token}" }
+          ).body
+        rescue Exception => e
+          add_or_append_to_errors(barcode, "Bad response from NYPL Bibs API")
+        end
       else
         @logger.error("Not valid customer code for the barcode: #{barcode}.")
+        add_or_append_to_errors(barcode, "No valid customer code")
       end
     end
 

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -21,7 +21,8 @@ class SCSBXMLFetcher
     @oauth_key = options[:oauth_key]
     @oauth_secret = options[:oauth_secret]
     @platform_api_url = options[:platform_api_url]
-    @barcode_to_customer_code_mapping = options[:barcode_to_customer_code_mapping]
+    @barcode_to_customer_code_mapping =
+      options[:barcode_to_customer_code_mapping]
     @logger = NyplLogFormatter.new(STDOUT)
   end
 
@@ -42,14 +43,13 @@ class SCSBXMLFetcher
             headers: { 'Authorization' => "Bearer #{@oauth_token}" }
           ).body
         rescue Exception => e
-          add_or_append_to_errors(barcode, "Bad response from NYPL Bibs API")
+          add_or_append_to_errors(barcode, 'Bad response from NYPL Bibs API')
         end
       else
         @logger.error("Not valid customer code for the barcode: #{barcode}.")
-        add_or_append_to_errors(barcode, "Not have valid customer code")
+        add_or_append_to_errors(barcode, 'Not have valid customer code')
       end
     end
-
     results
   end
 

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -1,8 +1,11 @@
 require 'oauth2'
 require 'httparty'
 require 'nypl_log_formatter'
+# require 'errorable'
 
 class SCSBXMLFetcher
+  # include Errorable
+
   # options is a hash used to instantiate a SCSBXMLFetcher
   #  options token [String]
   #  options oauth_url [String]
@@ -27,6 +30,7 @@ class SCSBXMLFetcher
     results = {}
     @barcode_to_customer_code_mapping.each do |barcode, customer_code|
       if customer_code
+        # begin
         results[barcode] = HTTParty.get(
           "#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
           query: {
@@ -36,6 +40,12 @@ class SCSBXMLFetcher
           },
           headers: { 'Authorization' => "Bearer #{@oauth_token}" }
         ).body
+        # rescue Exception => e
+          # barcodes.each do |barcode|
+          #   add_or_append_to_errors(barcode, "Bad response from SCSB API")
+          # end
+          
+        # end
       else
         @logger.error("Not valid customer code for the barcode: #{barcode}.")
       end
@@ -44,7 +54,7 @@ class SCSBXMLFetcher
     results
   end
 
-private
+  private
 
   # TODO: We should cache tokens and retry once they expire
   def set_token

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -1,7 +1,7 @@
 require 'oauth2'
 require 'httparty'
 require 'nypl_log_formatter'
-require './lib/errorable'
+require File.join('.', 'lib', 'errorable')
 
 class SCSBXMLFetcher
   include Errorable
@@ -21,8 +21,7 @@ class SCSBXMLFetcher
     @oauth_key = options[:oauth_key]
     @oauth_secret = options[:oauth_secret]
     @platform_api_url = options[:platform_api_url]
-    @barcode_to_customer_code_mapping =
-      options[:barcode_to_customer_code_mapping]
+    @barcode_to_customer_code_mapping = options[:barcode_to_customer_code_mapping]
     @logger = NyplLogFormatter.new(STDOUT)
   end
 

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -1,22 +1,20 @@
 require 'spec_helper'
 
 describe SCSBXMLFetcher do
-  describe "translate_to_scsb_xml" do
-
-    it "maps a hash of barcodes => customer_code to a hash of barcodes and the values are SCSBXML Strings" do
+  describe 'translate_to_scsb_xml' do
+    it 'maps a hash of barcodes => customer_code to a hash of barcodes and the values are SCSBXML Strings' do
       # Mock OAuth
-      fake_oauth_client = instance_double("OAuth2::Client", :client_credentials => double(:get_token => double({:token => "hi"})))
+      fake_oauth_client = instance_double('OAuth2::Client', 'client_credentials' => double('get_token' => double('token' => 'hi')))
       expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(fake_oauth_client)
 
       # Mock actual call to nypl-bibs
-      fake_nypl_bibs_response = double()
-      allow(fake_nypl_bibs_response).to receive(:body).at_least(:once) { "<?xml version=\"1.0\" ?><bibRecords></bibRecords>" }
+      fake_nypl_bibs_response = double
+      allow(fake_nypl_bibs_response).to receive(:body).at_least(:once) { '<?xml version=\"1.0\" ?><bibRecords></bibRecords>' }
       expect(HTTParty).to receive(:get).at_least(:once).and_return(fake_nypl_bibs_response)
-      
-      fetcher = SCSBXMLFetcher.new({barcode_to_customer_code_mapping: {'1234' => "NA", "5678" => nil}})
 
-      expect(fetcher.translate_to_scsb_xml).to eq({'1234' => "<?xml version=\"1.0\" ?><bibRecords></bibRecords>"})
+      fetcher = SCSBXMLFetcher.new(barcode_to_customer_code_mapping: { '1234' => 'NA', '5678' => nil })
+
+      expect(fetcher.translate_to_scsb_xml).to eq('1234' => '<?xml version=\"1.0\" ?><bibRecords></bibRecords>')
     end
   end
-
 end

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -1,20 +1,55 @@
 require 'spec_helper'
 
 describe SCSBXMLFetcher do
-  describe 'translate_to_scsb_xml' do
-    it 'maps a hash of barcodes => customer_code to a hash of barcodes and the values are SCSBXML Strings' do
+  describe 'errors' do
+    before do
+      @fetcher = SCSBXMLFetcher.new(barcode_to_customer_code_mapping: { '1234' => 'NA', '5678' => nil })
       # Mock OAuth
-      fake_oauth_client = instance_double('OAuth2::Client', 'client_credentials' => double('get_token' => double('token' => 'hi')))
-      expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(fake_oauth_client)
+      @fake_oauth_client = instance_double('OAuth2::Client', 'client_credentials' => double('get_token' => double('token' => 'hi')))
+    end
+
+    it 'returns an empty hash before translate_to_scsb_xml is called' do
+      expect(@fetcher.errors).to eq({})
+    end
+
+    it "contains an error if there's an error with the connection to NYPL Bibs" do
+      expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(@fake_oauth_client)
+      # Mock actual call to nypl-bibs
+      expect(HTTParty).to receive(:get).at_least(:once).and_raise('an exception')
+
+      @fetcher.translate_to_scsb_xml
+      error_message = 'Bad response from NYPL Bibs API'
+      expect(@fetcher.errors['1234']).to include(error_message)
+    end
+
+    it 'contains an error if the barcode does not have a valid customer code' do
+      expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(@fake_oauth_client)
+      # Mock actual call to nypl-bibs
+      expect(HTTParty).to receive(:get).at_least(:once).and_raise('an exception')
+
+      @fetcher.translate_to_scsb_xml
+      error_message = 'Not have valid customer code'
+      expect(@fetcher.errors['5678']).to include(error_message)
+    end
+  end
+
+  describe 'translate_to_scsb_xml' do
+    before do
+      # Mock OAuth
+      @fake_oauth_client = instance_double('OAuth2::Client', 'client_credentials' => double('get_token' => double('token' => 'hi')))
 
       # Mock actual call to nypl-bibs
-      fake_nypl_bibs_response = double
-      allow(fake_nypl_bibs_response).to receive(:body).at_least(:once) { '<?xml version=\"1.0\" ?><bibRecords></bibRecords>' }
-      expect(HTTParty).to receive(:get).at_least(:once).and_return(fake_nypl_bibs_response)
+      @fake_nypl_bibs_response = double
+      allow(@fake_nypl_bibs_response).to receive(:body).at_least(:once) { '<?xml version=\"1.0\" ?><bibRecords></bibRecords>' }
 
-      fetcher = SCSBXMLFetcher.new(barcode_to_customer_code_mapping: { '1234' => 'NA', '5678' => nil })
+      @fetcher = SCSBXMLFetcher.new(barcode_to_customer_code_mapping: { '1234' => 'NA', '5678' => nil })
+    end
 
-      expect(fetcher.translate_to_scsb_xml).to eq('1234' => '<?xml version=\"1.0\" ?><bibRecords></bibRecords>')
+    it 'maps a hash of barcodes => customer_code to a hash of barcodes and the values are SCSBXML Strings' do
+      expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(@fake_oauth_client)
+      expect(HTTParty).to receive(:get).at_least(:once).and_return(@fake_nypl_bibs_response)
+      expect(@fetcher.translate_to_scsb_xml).to eq('1234' => '<?xml version=\"1.0\" ?><bibRecords></bibRecords>')
+      expect(@fetcher.errors['5678']).to eq(['Not have valid customer code'])
     end
   end
 end


### PR DESCRIPTION
This PR is for implement error handling to SCSBXMLFetcher. It will throw errors if the connection to NYPL Bibs API is not available or a barcode doesn't have a valid customer code. The PR also includes the related unit tests.