### PR TITLE
Ktp/gather errors and stop submiting if no valid xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config/.env
+.DS_Store
 .rubocop.yml
 .rubocop_todo.yml

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -42,9 +42,9 @@ class SCSBXMLFetcher
             headers: { 'Authorization' => "Bearer #{@oauth_token}" }
           ).body
 
-          # checks the response_body to see if it contains valid XML
+          # checks response_body to see if it contains valid XML
           if response_body.empty?
-            @logger.error("Not valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
+            @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
             add_or_append_to_errors(barcode, 'Not have valid SCSB XML')
           else
             results[barcode] = response_body
@@ -53,7 +53,7 @@ class SCSBXMLFetcher
           add_or_append_to_errors(barcode, 'Bad response from NYPL Bibs API')
         end
       else
-        @logger.error("Not valid customer code for the barcode: #{barcode}.")
+        @logger.error("No valid customer code for the barcode: #{barcode}.")
         add_or_append_to_errors(barcode, 'Not have valid customer code')
       end
     end

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -32,7 +32,7 @@ class SCSBXMLFetcher
     @barcode_to_attributes_mapping.each do |barcode, scsb_attributes|
       if scsb_attributes['customerCode']
         begin
-          response_body = HTTParty.get(
+          response = HTTParty.get(
             "#{@platform_api_url}/api/v0.1/recap/nypl-bibs",
             query: {
               customerCode: scsb_attributes['customerCode'],
@@ -40,14 +40,14 @@ class SCSBXMLFetcher
               includeFullBibTree: 'false'
             },
             headers: { 'Authorization' => "Bearer #{@oauth_token}" }
-          ).body
+          )
 
           # checks response_body to see if it contains valid XML
-          if response_body.empty?
+          if response.code >= 400
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
             add_or_append_to_errors(barcode, 'Not have valid SCSB XML')
           else
-            results[barcode] = response_body
+            results[barcode] = response.body
           end
         rescue Exception => e
           add_or_append_to_errors(barcode, 'Bad response from NYPL Bibs API')

--- a/lib/submit_collection_updater.rb
+++ b/lib/submit_collection_updater.rb
@@ -20,6 +20,7 @@ class SubmitCollectionUpdater
     @api_key = options[:api_key]
     @is_gcd_protected = options[:is_gcd_protected] || false
     @is_dry_run = options[:is_dry_run]
+    @logger = NyplLogFormatter.new(STDOUT)
   end
 
   def update_scsb_items
@@ -28,8 +29,10 @@ class SubmitCollectionUpdater
     else
       puts "Updating the following #{@barcode_to_scsb_xml_mapping.keys.length} barcodes: #{@barcode_to_scsb_xml_mapping.keys.join(',')}"
       @barcode_to_scsb_xml_mapping.each do |barcode, scsb_xml|
+        # it stops calling the API to update the record if no valid XML
         if scsb_xml.empty?
           add_or_append_to_errors(barcode, 'Not have valid SCSB XML. Stops submitting this record')
+          @logger.error("No valid XML for the barcode: #{barcode}. It has stopped updating the record.")
         else
           update_item(barcode, scsb_xml)
         end

--- a/lib/submit_collection_updater.rb
+++ b/lib/submit_collection_updater.rb
@@ -28,7 +28,11 @@ class SubmitCollectionUpdater
     else
       puts "Updating the following #{@barcode_to_scsb_xml_mapping.keys.length} barcodes: #{@barcode_to_scsb_xml_mapping.keys.join(',')}"
       @barcode_to_scsb_xml_mapping.each do |barcode, scsb_xml|
-        update_item(barcode, scsb_xml)
+        if scsb_xml.empty?
+          add_or_append_to_errors(barcode, 'Not have valid SCSB XML. Stops submitting this record')
+        else
+          update_item(barcode, scsb_xml)
+        end
       end
     end
   end

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -31,6 +31,18 @@ describe SCSBXMLFetcher do
       error_message = 'Not have valid customer code'
       expect(@fetcher.errors['5678']).to include(error_message)
     end
+
+    it 'contains an error if the response does not returns a valid XML' do
+      expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(@fake_oauth_client)
+      # Mock actual call to nypl-bibs
+      @fake_nypl_bibs_response = double
+      allow(@fake_nypl_bibs_response).to receive(:body).at_least(:once) { '' }
+      expect(HTTParty).to receive(:get).at_least(:once).and_return(@fake_nypl_bibs_response)
+
+      @fetcher.translate_to_scsb_xml
+      error_message = 'Not have valid SCSB XML'
+      expect(@fetcher.errors['1234']).to include(error_message)
+    end
   end
 
   describe 'translate_to_scsb_xml' do

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SCSBXMLFetcher do
   describe 'errors' do
     before do
-      @fetcher = SCSBXMLFetcher.new(barcode_to_attributes_mapping: { '1234' => {'customerCode' => 'NA'}, '5678' => {'customerCode' => nil} })
+      @fetcher = SCSBXMLFetcher.new(barcode_to_attributes_mapping: { '1234' => { 'customerCode' => 'NA' }, '5678' => { 'customerCode' => nil } })
       # Mock OAuth
       @fake_oauth_client = instance_double('OAuth2::Client', 'client_credentials' => double('get_token' => double('token' => 'hi')))
     end
@@ -54,7 +54,7 @@ describe SCSBXMLFetcher do
       @fake_nypl_bibs_response = double
       allow(@fake_nypl_bibs_response).to receive(:body).at_least(:once) { '<?xml version=\"1.0\" ?><bibRecords></bibRecords>' }
 
-      @fetcher = SCSBXMLFetcher.new(barcode_to_attributes_mapping: { '1234' => {'customerCode' => 'NA'}, '5678' => {'customerCode' => nil} })
+      @fetcher = SCSBXMLFetcher.new(barcode_to_attributes_mapping: { '1234' => { 'customerCode' => 'NA' }, '5678' => { 'customerCode' => nil } })
     end
 
     it 'maps a hash of barcodes => customer_code to a hash of barcodes and the values are SCSBXML Strings' do

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -36,7 +36,7 @@ describe SCSBXMLFetcher do
       expect(OAuth2::Client).to receive(:new).at_least(:once).and_return(@fake_oauth_client)
       # Mock actual call to nypl-bibs
       @fake_nypl_bibs_response = double
-      allow(@fake_nypl_bibs_response).to receive(:body).at_least(:once) { '' }
+      allow(@fake_nypl_bibs_response).to receive(:code).at_least(:once) { 500 }
       expect(HTTParty).to receive(:get).at_least(:once).and_return(@fake_nypl_bibs_response)
 
       @fetcher.translate_to_scsb_xml
@@ -52,6 +52,7 @@ describe SCSBXMLFetcher do
 
       # Mock actual call to nypl-bibs
       @fake_nypl_bibs_response = double
+      allow(@fake_nypl_bibs_response).to receive(:code).at_least(:once) { 200 }
       allow(@fake_nypl_bibs_response).to receive(:body).at_least(:once) { '<?xml version=\"1.0\" ?><bibRecords></bibRecords>' }
 
       @fetcher = SCSBXMLFetcher.new(barcode_to_attributes_mapping: { '1234' => { 'customerCode' => 'NA' }, '5678' => { 'customerCode' => nil } })

--- a/spec/submit_collection_updater_spec.rb
+++ b/spec/submit_collection_updater_spec.rb
@@ -60,6 +60,22 @@ describe SubmitCollectionUpdater do
 
       updater.update_scsb_items
     end
+
+    it 'stops submitting and throws an error if there is no valid XML' do
+      xml = ''
+      request_headers = {Accept: "application/json", api_key: "fake-key", "Content-Type": 'application/json'}
+
+      updater = SubmitCollectionUpdater.new(
+        barcode_to_scsb_xml_mapping: {"456" => xml},
+        api_url: "http://example.com",
+        api_key: 'fake-key'
+      )
+
+      updater.update_scsb_items
+
+      error_message = 'Not have valid SCSB XML. Stops submitting this record'
+      expect(updater.errors['456']).to include(error_message)
+    end
   end
 
 end


### PR DESCRIPTION
Add the function to throw an error if we don't get valid XML back from NYPL-Bibs. And since we don't have valid XML, the app now won't call the API to update the record on SCSB.