### PR TITLE
Added a new key to our Mail class to add cc email addresses.

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -14,4 +14,5 @@ SMTP_DOMAIN=email-smtp.us-east-1.amazonaws.com
 SMTP_USER_NAME=a-username
 SMTP_PASSWORD=a-password
 EMAIL_FROM_ADDRESS=sender@example.com
+EMAIL_CC_ADDRESSES=cc@example.com
 ENVIRONMENT=[development|production]

--- a/config/.env.example
+++ b/config/.env.example
@@ -14,5 +14,5 @@ SMTP_DOMAIN=email-smtp.us-east-1.amazonaws.com
 SMTP_USER_NAME=a-username
 SMTP_PASSWORD=a-password
 EMAIL_FROM_ADDRESS=sender@example.com
-EMAIL_CC_ADDRESSES=cc@example.com
+EMAIL_CC_ADDRESSES=cc1@example.com,cc2@example.com
 ENVIRONMENT=[development|production]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,4 +14,5 @@ smtp_domain:    <%= ENV['SMTP_DOMAIN'] %>
 smtp_user_name: <%= ENV['SMTP_USER_NAME'] %>
 smtp_password:  <%= ENV['SMTP_PASSWORD'] %>
 email_from_address: <%= ENV['EMAIL_FROM_ADDRESS'] %>
+email_cc_addresses: <%= ENV['EMAIL_CC_ADDRESSES'] %>
 environment:  <%= ENV['ENVIRONMENT'] %>

--- a/lib/message_handler.rb
+++ b/lib/message_handler.rb
@@ -127,6 +127,7 @@ class MessageHandler
       error_hashes: errors,
       sqs_message: @parsed_message,
       from_address:  @settings['email_from_address'],
+      cc_addresses:  @settings['email_cc_addresses'],
       mailer_domain: @settings['smtp_domain'],
       mailer_username: @settings['smtp_user_name'],
       mailer_password: @settings['smtp_password'],

--- a/spec/error_mailer_spec.rb
+++ b/spec/error_mailer_spec.rb
@@ -1,22 +1,44 @@
 require 'spec_helper'
+require 'mail'
 
 describe ErrorMailer do
+  before do
+    Mail::TestMailer.deliveries.clear
+    @error_report_one = {
+      "1234" => ["here's an error", "and another"],
+      "5678" => ["meow"]}
+
+    @error_report_two = {
+      "1234" => ["and finally"],
+      "001" => ["woof"]}
+  end
+
   describe "all_errors" do
     it "will collapse errors into one hash" do
-      error_report_one = {
-        "1234" => ["here's an error", "and another"],
-        "5678" => ["meow"]}
-
-      error_report_two = {
-        "1234" => ["and finally"],
-        "001" => ["woof"]}
-
-      error_mailer = ErrorMailer.new(sqs_message: {}, error_hashes: [error_report_one, error_report_two])
+      error_mailer = ErrorMailer.new(sqs_message: {}, error_hashes: [@error_report_one, @error_report_two])
       expect(error_mailer.all_errors).to eq({
         "1234" => ["here's an error", "and another", "and finally"],
         "5678" => ["meow"],
         "001" => ["woof"]
       })
+    end
+  end
+
+  describe "send_error_email" do
+    it "will send and cc the errors to the respectively assigned email addresses" do
+      error_mailer = ErrorMailer.new(
+        from_address: "from_address@example.com",
+        cc_addresses: "cc_1@example.com,cc_2@example.com",
+        sqs_message: {'barcodes' => ['111', '123']},
+        error_hashes: [@error_report_one, @error_report_two],
+        environment:  'test'
+      )
+
+      error_mailer.send_error_email
+
+      email = Mail::TestMailer.deliveries.last
+      expect(email.from).to eq(['from_address@example.com'])
+      expect(email.cc).to eq(['cc_1@example.com','cc_2@example.com'])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-
 Dir[File.join(File.dirname(__FILE__), '..', 'lib', '*.rb')].each {|file| require file }
 
 RSpec.configure do |config|


### PR DESCRIPTION
We need to CC one or multiple email addresses with our error messages. To do this, we have to make a new environment variable that indicates the CC email addresses. Note that we can have multiple addresses that are divided with commas.

Following with that, we have to add new variable in settings.yml, message_handler.rb, and finally the adjustment in lib/error_mailer.rb

This PR also includes the tests for testing if we assign the correct emails.