### PR TITLE
Fix nexted customerCode issue

### DIFF
--- a/lib/barcode_to_scsb_attributes_mapper.rb
+++ b/lib/barcode_to_scsb_attributes_mapper.rb
@@ -69,8 +69,17 @@ private
       parsed_body['searchResultRows'].each do |result_row|
         # guard against the off-chance SCSB returns barcode that wasn't requested
         if @barcodes.include? result_row['barcode']
-          # result[result_row['barcode']] = {'customerCode' => result_row['customerCode']}
           result[result_row['barcode']] = result_row
+        end
+
+        # https://jira.nypl.org/browse/SCC-310 describes a case where in some cases, the top-level
+        # barcode & customerCode are null and we must descend into the `searchItemResultRows` Array
+        if result_row['barcode'].nil?
+          result_row['searchItemResultRows'].each do |item_result_row|
+            if @barcodes.include? item_result_row['barcode']
+              result[item_result_row['barcode']] = item_result_row
+            end
+          end
         end
       end
 


### PR DESCRIPTION
In [SCC-310](https://jira.nypl.org/browse/SCC-310), we discovered that there are sometimes
search responses will `null` barcode & `customerCode` attributes at the "top level" of the response.
They can be nested inside properties of elements of `searchItemResultRows`.

This code looks inside `searchItemResultRows`, in the case where the top level barcode is null.
