### PR TITLE
Update transfer logic SCC-427

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ end
 
 Our branches (in order or stability are):
 
-| Branch      | Environment | AWS Account     |
-|:------------|:------------|:----------------|
-| master      | none        | none            |
-| development | development | aws-sandbox     |
-| production  | production  | aws-digital-dev |
+| Branch      | Environment | AWS Account      |
+|:------------|:------------|:-----------------|
+| master      | none        | none             |
+| development | development | nypl-sandbox     |
+| qa          | qa          | nypl-digital-dev |
+| production  | production  | nypl-digital-dev |
 
 ### Cutting A Feature Branch
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 |:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `master`      | [![Build Status](https://travis-ci.org/NYPL-discovery/scsb_item_updater.svg?branch=master)](https://travis-ci.org/NYPL-discovery/scsb_item_updater)      |
 | `development` | [![Build Status](https://travis-ci.org/NYPL-discovery/scsb_item_updater.svg?branch=development)](https://travis-ci.org/NYPL-discovery/scsb_item_updater) |
+| `qa`          | [![Build Status](https://travis-ci.org/NYPL-discovery/scsb_item_updater.svg?branch=qa)](https://travis-ci.org/NYPL-discovery/scsb_item_updater)          |
 | `production`  | [![Build Status](https://travis-ci.org/NYPL-discovery/scsb_item_updater.svg?branch=production)](https://travis-ci.org/NYPL-discovery/scsb_item_updater)  |
 
 This app consumes messages produced by [NYPL/nypl-recap-admin](https://github.com/NYPL/nypl-recap-admin).  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ From an IRB session (`$bundle exec irb -r ./boot.rb`).
 
 This [Stack Overflow thread](http://stackoverflow.com/questions/8798357/inspect-and-retry-resque-jobs-via-redis-cli) has good tips on ways to inspect the queue.
 
-```
+```ruby
 > Resque.info
   => {:pending=>0, :processed=>193, :queues=>1, :workers=>2, :working=>0, :failed=>168, :servers=>["redis://fqdn.com:6379/0"], :environment=>"development"}
 

--- a/lib/item_transferer.rb
+++ b/lib/item_transferer.rb
@@ -1,5 +1,6 @@
 require File.join(__dir__, '..', 'boot')
 require File.join('.', 'lib', 'errorable')
+require 'securerandom'
 
 class ItemTransferer
   include Errorable
@@ -46,15 +47,17 @@ class ItemTransferer
   #
   def request_body(item_attributes)
     body = {
-     "holdingTransfers": [
+     "itemTransfers": [
        {
          "source": {
            "owningInstitutionBibId": item_attributes['owningInstitutionBibId'],
-           "owningInstitutionHoldingsId": item_attributes['owningInstitutionHoldingsId']
+           "owningInstitutionHoldingsId": item_attributes['owningInstitutionHoldingsId'],
+           "owningInstitutionItemId": item_attributes['owningInstitutionItemId']
          },
          "destination": {
            "owningInstitutionBibId": bib_with_leading_dot,
-           "owningInstitutionHoldingsId": item_attributes['owningInstitutionHoldingsId']
+           "owningInstitutionHoldingsId": "#{bib_with_leading_dot}-#{SecureRandom.uuid}",
+           "owningInstitutionItemId": item_attributes['owningInstitutionItemId']
          }
        }
      ],


### PR DESCRIPTION
Hey @thisisstephenbetts 

This addresses the changes in [SCC-427](https://jira.nypl.org/browse/SCC-427).

## First Some Cleanup

In README I've...

1.  Added `qa` in our table of build badges. We don't have a `qa` branch in github yet, but it's coming soon.
1.  Added the 'ruby' code hint to a code example.
1. Added `qa` branch to the git workflow section & fixed some typos in the names of our AWS accounts.

## The Significant Change

I changed the body of what we POST to `/sharedCollection/transferHoldingsAndItems` to reflect Kate's notes in the Jira ticket (and my followup comment in the ticket).

Finally - the specs had to change a bit to reflect the new payload (and the fact that `destination -> owningInstitutionHoldingsId` is randomized (had to stub `SecureRandom.uuid` to make the expectation reliable)