### PR TITLE
Non-descriptive error in SCSBuster transfer 

### DIFF
--- a/lib/item_transferer.rb
+++ b/lib/item_transferer.rb
@@ -29,7 +29,7 @@ class ItemTransferer
         end
       rescue Exception => e
         # TODO: log...
-        add_or_append_to_errors(barcode, "error connecting to transferHoldingsAndItems: #{e.message}")
+        add_or_append_to_errors(barcode, "error in making request to transferHoldingsAndItems: #{e.message}")
       end
     end
   end

--- a/lib/item_transferer.rb
+++ b/lib/item_transferer.rb
@@ -25,11 +25,11 @@ class ItemTransferer
 
         parsed_body = JSON.parse(response.body)
         if parsed_body["message"] != "Success"
-          add_or_append_to_errors(barcode, parsed_body['holdingTransferResponses'][0]['message'])
+          add_or_append_to_errors(barcode, parsed_body['itemTransferResponses'][0]['message'])
         end
       rescue Exception => e
         # TODO: log...
-        add_or_append_to_errors(barcode, 'error connecting to transferHoldingsAndItems')
+        add_or_append_to_errors(barcode, "error connecting to transferHoldingsAndItems: #{e.message}")
       end
     end
   end

--- a/spec/item_transferer_spec.rb
+++ b/spec/item_transferer_spec.rb
@@ -76,7 +76,7 @@ describe ItemTransferer do
       expect(HTTParty).to receive(:post).and_raise(Exception)
       item_transferer = ItemTransferer.new(barcode_to_attributes_mapping: {"1234" => {}})
       item_transferer.transfer!
-      expect(item_transferer.errors).to eq({"1234" => ["error connecting to transferHoldingsAndItems: Exception"]})
+      expect(item_transferer.errors).to eq({"1234" => ["error in making request to transferHoldingsAndItems: Exception"]})
     end
   end
 end

--- a/spec/item_transferer_spec.rb
+++ b/spec/item_transferer_spec.rb
@@ -56,7 +56,7 @@ describe ItemTransferer do
 
     it "parrots the 'error' message from SCSB's response if it exists" do
       expect(SecureRandom).to receive(:uuid).at_least(:once).and_return('ABC-123')
-      fake_api_response = double(body: JSON.generate({message: "Failed", holdingTransferResponses: [{"message": "Source holdings is not under source bib"}]}))
+      fake_api_response = double(body: JSON.generate({message: "Failed", itemTransferResponses: [{"message": "Source holdings is not under source bib"}]}))
       expect(HTTParty).to receive(:post).with(
         "http://example.com/sharedCollection/transferHoldingsAndItems",
         headers: {
@@ -76,7 +76,7 @@ describe ItemTransferer do
       expect(HTTParty).to receive(:post).and_raise(Exception)
       item_transferer = ItemTransferer.new(barcode_to_attributes_mapping: {"1234" => {}})
       item_transferer.transfer!
-      expect(item_transferer.errors).to eq({"1234" => ["error connecting to transferHoldingsAndItems"]})
+      expect(item_transferer.errors).to eq({"1234" => ["error connecting to transferHoldingsAndItems: Exception"]})
     end
   end
 end


### PR DESCRIPTION
Heide had seen problems trying to transfer an item in SCSBuster. She receives a not-very-descriptive error message in the standard error email saying "error connecting to transferHoldingsAndItems". 

Turns out we were checking for success message in `holdingTransferResponses` element of the JSON response, but we had previously changed to using `itemTransferResponses` instead and should have been looking for. Just needed to fix that, and took the opportunity to add a bit more detail to the error messages.