### PR TITLE
Adds: process sqs message immediately when..

### DIFF
--- a/lib/sqs_message_handler.rb
+++ b/lib/sqs_message_handler.rb
@@ -16,9 +16,9 @@ class SQSMessageHandler
   end
 
   def handle
-    if old_enough?
+    @parsed_message = JSON.parse(@message.body)
+    if old_enough? || process_immediately?
       @logger.info "Message body: #{@message.body} with attributes #{@message.attributes} and user_attributes of #{@message.message_attributes}"
-      @parsed_message = JSON.parse(@message.body)
       if valid?
         Resque.enqueue(ProcessResqueMessage, @message.body)
         @sqs_client.delete_message(queue_url: @settings['sqs_queue_url'], receipt_handle: @message.receipt_handle)
@@ -34,6 +34,14 @@ class SQSMessageHandler
 
   def valid?
     (@parsed_message['action'] && VALID_ACTIONS.include?(@parsed_message['action']))
+  end
+
+  # Checks parsed message for conditions that obligate processing immediately
+  # (i.e. without waiting for minimum_message_age_seconds)
+  def process_immediately?
+    process_immediately = @parsed_message['source'] == 'bib-item-store-update'
+    @logger.debug("Message '#{@message.body}' appears to be triggered by an organic update from bib/item store; Process immediately") if process_immediately
+    process_immediately
   end
 
   def old_enough?

--- a/spec/sqs_message_handler_spec.rb
+++ b/spec/sqs_message_handler_spec.rb
@@ -19,6 +19,43 @@ describe SQSMessageHandler do
     message_handler.handle
   end
 
+  describe "handling conditions where we should process the message" do
+    before(:each) do
+      @fake_sqs_client = double(:delete_message)
+      @sqs_message_handler_options = {
+        sqs_client: @fake_sqs_client,
+        settings: {
+          'sqs_queue_url' => 'http://example.com',
+          'minimum_message_age_seconds' => "300"
+        }
+      }
+    end
+
+    it "will try to process a message if message is old enough" do
+      three_hundred_seconds_ago = Time.now.to_i - 300
+      fake_message = double(:body => JSON.generate({}), receipt_handle: "some-id", message_attributes: {}, :attributes => {"SentTimestamp" => three_hundred_seconds_ago.to_s})
+      message_handler = SQSMessageHandler.new(@sqs_message_handler_options.merge(message: fake_message))
+      expect(message_handler.instance_variable_get('@logger')).to_not receive(:debug).with("Message '{\"source\":\"bib-item-store-update\"}' is not old enough to process. It can be processed in 300 seconds")
+      expect(@fake_sqs_client).to receive(:delete_message).with(queue_url: 'http://example.com', receipt_handle: "some-id")
+      message_handler.handle
+    end
+
+    it "will try to process a 'young' message if message originated via organic Bib/Item service update" do
+      fake_message = double(:body => JSON.generate({ source: 'bib-item-store-update' }), receipt_handle: "some-id", message_attributes: {}, :attributes => {"SentTimestamp" => Time.now.to_i.to_s})
+      message_handler = SQSMessageHandler.new(@sqs_message_handler_options.merge(message: fake_message))
+      expect(message_handler.instance_variable_get('@logger')).to_not receive(:debug).with("Message '{\"source\":\"bib-item-store-update\"}' is not old enough to process. It can be processed in 300 seconds")
+      expect(@fake_sqs_client).to receive(:delete_message).with(queue_url: 'http://example.com', receipt_handle: "some-id")
+      message_handler.handle
+    end
+
+    it "will log, without processing, a 'young' process with an unsupported source" do
+      fake_message = double(:body => JSON.generate({ source: '' }), message_attributes: {}, :attributes => {"SentTimestamp" => Time.now.to_i.to_s})
+      message_handler = SQSMessageHandler.new(@sqs_message_handler_options.merge(message: fake_message))
+      expect(message_handler.instance_variable_get('@logger')).to receive(:debug).with("Message '{\"source\":\"\"}' is not old enough to process. It can be processed in 300 seconds")
+      message_handler.handle
+    end
+  end
+
   describe "handling a message with a value for 'action' that is not in the whitelist" do
 
     before do
@@ -34,5 +71,4 @@ describe SQSMessageHandler do
       message_handler.handle
     end
   end
-
 end


### PR DESCRIPTION
Adds support for processing the SQS message immediately (rather than
waiting for the configured delay, which is the default) for messages
generated as a direct result of organic updates in the Bib/Item service.
Updates triggered by the Bib/Item service do not require any delay; The
delay is used to accomodate slow data propogation *to* the Bib/Item
service, which is not a concern if the SQS message is created after
those updates have been made.