### PR TITLE
Improve error messages

### DIFF
--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -26,7 +26,7 @@ class SCSBXMLFetcher
           # checks response_body to see if it contains valid XML
           if response.code >= 400
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
-            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{response.parsed_response['error']}")
+            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{response.parsed_response['error']}.")
           else
             results[barcode] = response.body
           end

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -26,7 +26,7 @@ class SCSBXMLFetcher
           # checks response_body to see if it contains valid XML
           if response.code >= 400
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
-            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{reponse.error}.")
+            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{response.parsed_response['error']}")
           else
             results[barcode] = response.body
           end

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -26,7 +26,7 @@ class SCSBXMLFetcher
           # checks response_body to see if it contains valid XML
           if response.code >= 400
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
-            add_or_append_to_errors(barcode, 'did not have valid SCSB XML')
+            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{reponse.error}.")
           else
             results[barcode] = response.body
           end

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -29,10 +29,11 @@ describe SCSBXMLFetcher do
     end
 
     it 'contains an error if the response does not returns a valid XML' do
-      expect(@nypl_platform_client).to receive(:fetch_scsbxml_for).at_least(:once).and_return(double(code: 500))
+      expect(@nypl_platform_client).to receive(:fetch_scsbxml_for).at_least(:once)
+      .and_return(double(code: 500, parsed_response: { "error" => "SCSB XML Formatter determined that no items were suitable for export to Recap." }))
 
       @fetcher.translate_to_scsb_xml
-      error_message = 'did not have valid SCSB XML'
+      error_message = 'did not have valid SCSB XML. SCSB XML Formatter determined that no items were suitable for export to Recap.'
       expect(@fetcher.errors['1234']).to include(error_message)
     end
   end

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -30,7 +30,7 @@ describe SCSBXMLFetcher do
 
     it 'contains an error if the response does not returns a valid XML' do
       expect(@nypl_platform_client).to receive(:fetch_scsbxml_for).at_least(:once)
-      .and_return(double(code: 500, parsed_response: { "error" => "SCSB XML Formatter determined that no items were suitable for export to Recap." }))
+      .and_return(double(code: 500, parsed_response: { "error" => "SCSB XML Formatter determined that no items were suitable for export to Recap" }))
 
       @fetcher.translate_to_scsb_xml
       error_message = 'did not have valid SCSB XML. SCSB XML Formatter determined that no items were suitable for export to Recap.'


### PR DESCRIPTION
This PR updates the method to include the error message from scsb-ongoing-accessions. It now will take the error messages returned from `/api/v0.1/recap/nypl-bibs` and add the message to the end.

Related PR for updating more descriptive error messages for scsb-ongoing-accessions
https://github.com/NYPL-discovery/scsb-ongoing-accessions

I am trying to figure out a way to test it locally. So far I only compared the error message from `https://platformdocs.nypl.org/#/recap/get_v0_1_recap_nypl_bibs`
I would like to see if the response's structure if really like what I assume.

I am thinking I have to manually send a message to Amazon SQS?

