### PR TITLE
Rephrased error messages from recap/nypl-bibs

### DIFF
--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -26,7 +26,14 @@ class SCSBXMLFetcher
           # checks response_body to see if it contains valid XML
           if response.code >= 400
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
-            add_or_append_to_errors(barcode, "did not have valid SCSB XML. #{response.parsed_response['error']}.")
+
+            if response.parsed_response['error']
+              error_message_from_response = " This was because #{response.parsed_response['error']}."
+            else
+              error_message_from_response = " This was because of undefined error."
+            end
+
+            add_or_append_to_errors(barcode, "did not have valid SCSB XML.#{error_message_from_response}")
           else
             results[barcode] = response.body
           end

--- a/lib/scsbxml_fetcher.rb
+++ b/lib/scsbxml_fetcher.rb
@@ -28,9 +28,10 @@ class SCSBXMLFetcher
             @logger.error("No valid SCSB XML from NYPL-Bibs for the barcode: #{barcode}.")
 
             if response.parsed_response['error']
+              response.parsed_response['error'][0] = response.parsed_response['error'][0].downcase
               error_message_from_response = " This was because #{response.parsed_response['error']}."
             else
-              error_message_from_response = " This was because of undefined error."
+              error_message_from_response = " This was because of an undefined error."
             end
 
             add_or_append_to_errors(barcode, "did not have valid SCSB XML.#{error_message_from_response}")

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -30,10 +30,10 @@ describe SCSBXMLFetcher do
 
     it 'contains an error if the response does not returns a valid XML' do
       expect(@nypl_platform_client).to receive(:fetch_scsbxml_for).at_least(:once)
-      .and_return(double(code: 500, parsed_response: { "error" => "SCSB XML Formatter determined that no items were suitable for export to Recap" }))
+      .and_return(double(code: 500, parsed_response: { "error" => "Barcode not found in ItemService" }))
 
       @fetcher.translate_to_scsb_xml
-      error_message = 'did not have valid SCSB XML. This was because SCSB XML Formatter determined that no items were suitable for export to Recap.'
+      error_message = 'did not have valid SCSB XML. This was because barcode not found in ItemService.'
       expect(@fetcher.errors['1234']).to include(error_message)
     end
   end

--- a/spec/scsbxml_fetcher_spec.rb
+++ b/spec/scsbxml_fetcher_spec.rb
@@ -33,7 +33,7 @@ describe SCSBXMLFetcher do
       .and_return(double(code: 500, parsed_response: { "error" => "SCSB XML Formatter determined that no items were suitable for export to Recap" }))
 
       @fetcher.translate_to_scsb_xml
-      error_message = 'did not have valid SCSB XML. SCSB XML Formatter determined that no items were suitable for export to Recap.'
+      error_message = 'did not have valid SCSB XML. This was because SCSB XML Formatter determined that no items were suitable for export to Recap.'
       expect(@fetcher.errors['1234']).to include(error_message)
     end
   end


### PR DESCRIPTION
This PR rephrases the error messages we send to the users. The messages now better illustrate the cause of the errors.

Something might worth considering is that I noticed the responded error messages from `recap/nypl-bibs`start with capital characters. If we want to make it more like a natural sentence we can update the messages from that repo. But I am not sure if it is too finicky.