### PR TITLE
Adds COUNT env var to control resque workers

### DIFF
--- a/boot.rb
+++ b/boot.rb
@@ -37,6 +37,7 @@ Application.env = Application.settings['environment'] || 'development'
 # container dies.
 STDOUT.sync = true
 Application.logger = NyplLogFormatter.new(STDOUT)
+Application.logger.level = ENV['LOG_LEVEL'] || 'info'
 
 # Configure Redis
 Resque.redis = Application.settings['redis_domain_and_port']

--- a/config/.env.example
+++ b/config/.env.example
@@ -17,3 +17,4 @@ EMAIL_FROM_ADDRESS=sender@example.com
 EMAIL_CC_ADDRESSES=cc1@example.com,cc2@example.com
 ENVIRONMENT=[development|production]
 REDIS_DOMAIN_AND_PORT='127.0.0.1:6379'
+COUNT=1 # Controls number of Resque workers

--- a/config/.env.example
+++ b/config/.env.example
@@ -18,3 +18,4 @@ EMAIL_CC_ADDRESSES=cc1@example.com,cc2@example.com
 ENVIRONMENT=[development|production]
 REDIS_DOMAIN_AND_PORT='127.0.0.1:6379'
 COUNT=1 # Controls number of Resque workers
+LOG_LEVEL=info # May be error, info, debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
     environment:
       - QUEUE=*
       - REDIS_DOMAIN_AND_PORT=redis:6379
-    entrypoint: ["rake", "resque:work"]
+    entrypoint: ["rake", "resque:workers"]
     depends_on:
       - 'redis'


### PR DESCRIPTION
Adds COUNT environmental variable (default 1) to control number of
spawned resque:work threads to run. For the param to be honored, we must
change the rake task from `resque:work` to `resque:workers`.

It seems that the resque entry point is not controlled by code/config in git (?), so we'll also have to edit container properties in AWS console:
 - AWS > ECS > Task Definitions >  scsb-item-updater-qa
 - Click "Create Revision"
 - "Container Definitions" > scsb_item_updater_redis_consumer:
  - Change "Entry Point" to "rake,resque:workers"
  - Under "Environment Variables" add "COUNT", "3" (or some number > 1)

Also adds additional logging to `update` and `transfer` handlers to ensure we can track how long these tasks take (as well as drill down into elapsed time for several http-heavy sub-tasks). The approach taken here feels a little crude, but I wanted to be very noninvasive - no aliasing or blocks - so there's no risk the added logging breaks any functionality. I'm open to suggestions if anyone knows a cleaner way to get fairly granular reports on time ellapsed for tasks and http calls..