### PR TITLE
Adds "de-duping" to resque handler

### DIFF
--- a/lib/jobs/process_resque_message.rb
+++ b/lib/jobs/process_resque_message.rb
@@ -4,14 +4,77 @@ require 'json'
 
 # The Resque job that does all the actual handling of the message
 class ProcessResqueMessage
+  # Number of entries in @@sync_times hash we'll keep:
+  MAX_SYNC_TIMES_REMEMBERED = 100000
+
   @queue = :work_immediately
+  @@sync_times = {}
 
   # message a JSON string of the original SQS message body
   def self.perform(message)
     Application.logger.info("Processing a message from SQS", original_message: message)
     parsed_message = JSON.parse(message)
-    resque_message_handler = ResqueMessageHandler.new(settings: Application.settings, message: parsed_message)
-    resque_message_handler.handle
+    parsed_message['barcodes'] = remove_redundant_barcodes parsed_message
+    if parsed_message['barcodes'].empty?
+      Application.logger.debug("Skipping all barcodes in batch because each of them were written to SQS before the last sync for the same item", queued_at: parsed_message['queued_at'] )
+    else
+      resque_message_handler = ResqueMessageHandler.new(settings: Application.settings, message: parsed_message)
+      resque_message_handler.handle
+      record_last_sync_times_for_barcodes parsed_message['barcodes']
+    end
   end
 
+  # Given resque message with 'barcodes' and 'queued_at' properties, returns
+  # the subset of those barcodes that remains after "redundant" barcodes are
+  # removed. Redundant barcodes are those queued in SQS *before* the last time
+  # this tool synced them.
+  def self.remove_redundant_barcodes (message)
+    barcodes = message['barcodes']
+    queued_at = message['queued_at']
+    queued_at = queued_at.to_i unless queued_at.nil?
+    barcodes.select do |barcode|
+      last_synced = last_sync_time barcode
+      keep = queued_at.nil? || last_synced.nil? || queued_at > last_synced
+      Application.logger.debug("Skipping #{barcode} because it was written to SQS before the last sync for the same item", queued_at: queued_at, last_synced: last_synced ) if !keep
+      keep
+    end
+  end
+
+  # Return last sync time (in ms since epoc)
+  def self.last_sync_time (barcode)
+    @@sync_times[barcode]
+  end
+
+  # For a given array of barcodes, records current time as "sync time"
+  def self.record_last_sync_times_for_barcodes (barcodes)
+    current_time = Time.new.to_f * 1000
+    barcodes.each do |barcode|
+      @@sync_times[barcode] = current_time
+    end
+
+    truncate_sync_times
+  end
+
+  # Reduce size of @sync_times hash when necessary
+  def self.truncate_sync_times
+    # If size of hash is below max, noop:
+    return if @@sync_times.keys.size <= MAX_SYNC_TIMES_REMEMBERED
+
+    # Determine number to remove:
+    num_to_remove = @@sync_times.keys.size - MAX_SYNC_TIMES_REMEMBERED
+    # Let's remove 10% more than required to reduce how often we have to do this:
+    num_to_remove += (MAX_SYNC_TIMES_REMEMBERED * 0.1).to_i
+
+    # Map barcodes to barcode-synctime pairs:
+    barcodes_to_remove = @@sync_times.keys
+      .map { |k| [k, @@sync_times[k]] }
+      .sort_by { |entry| entry.last } # Sort by sync time
+      .slice(0, num_to_remove) # Truncate
+      .map { |entry| entry.first } # Map back to barcode
+
+    # Remove by barcode:
+    barcodes_to_remove.each { |barcode| @@sync_times.delete(barcode) }
+
+    Application.logger.debug("GC: Reduced @@sync_times map to #{@@sync_times.keys.size}")
+  end
 end

--- a/spec/process_resqueue_message_spec.rb
+++ b/spec/process_resqueue_message_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe ProcessResqueMessage do
+  before :each do
+    # Let's pretend we've just synced these two barcodes:
+    ProcessResqueMessage.record_last_sync_times_for_barcodes ['012345', '67890']
+  end
+
+  describe "#record_last_sync_times_for_barcodes" do
+    it "will record current times for an array of barcodes" do
+      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
+    end
+  end
+
+  describe "#last_sync_time" do
+    it "will return last sync time for a recently synced barcode" do
+      # Expect above to record "last synced time for both barcodes to current
+      # time (to within 100ms)
+      current_time = Time.new.to_f * 1000
+      expect(ProcessResqueMessage.last_sync_time('012345')).to be_within(100).of(current_time)
+      expect(ProcessResqueMessage.last_sync_time('67890')).to be_within(100).of(current_time)
+    end
+
+    it "will return nil barcode that hasn't been synced recently" do
+      expect(ProcessResqueMessage.last_sync_time('9999999999')).to be_nil
+    end
+  end
+
+  describe "#remove_redundant_barcodes" do
+    it "will remove barcodes that are redundant" do
+      # Let's pretend we now see a new message for one of those barcodes
+      # but it was queued 10s ago:
+      old_queued_at = Time.new.to_f * 1000 - 10000
+
+      # Because the new request to sync is older than the most recent sync,
+      # running it would be redundant, so we expect it will have been removed:
+      barcodes = ProcessResqueMessage.remove_redundant_barcodes({ "barcodes" => ['012345'], "queued_at" => old_queued_at })
+      expect(barcodes).to be_a(Array)
+      expect(barcodes.size).to eq(0)
+
+    end
+
+    it "will retain barcodes that are not redundant" do
+      # Let's pretend we now see a new message for one of those barcodes
+      # but it was queued 10s ago:
+      old_queued_at = Time.new.to_f * 1000 - 10000
+
+      # Because the new request to sync is older than the most recent sync,
+      # running it would be redundant, so we expect it will have been removed:
+      barcodes = ProcessResqueMessage.remove_redundant_barcodes({ "barcodes" => ['012345', '999999999'], "queued_at" => old_queued_at })
+      expect(barcodes).to be_a(Array)
+      expect(barcodes.size).to eq(1)
+      expect(barcodes[0]).to eq('999999999')
+    end
+  end
+
+  describe "#truncate_sync_times" do
+    before do
+      ProcessResqueMessage.const_set 'MAX_SYNC_TIMES_REMEMBERED', 10
+    end
+
+    it "will not truncate @@sync_times if not necessary" do
+      # We've already written two barcodes in root `before` so writing
+      # this third barcode should produce a @@sync_times hash of length 3
+      ProcessResqueMessage.record_last_sync_times_for_barcodes ['999999999']
+
+      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
+      expect(ProcessResqueMessage.class_eval('@@sync_times').keys.size).to eq(3)
+    end
+
+    it "will truncate @@sync_times when max entries exceeded" do
+      # Get current size of hash after above tests:
+      existing_sync_times_size = ProcessResqueMessage.class_eval('@@sync_times').keys.size
+
+      # Write 10 new barcodes:
+      num_to_write = 11 - existing_sync_times_size
+      generated_barcodes = barcodes = (0..num_to_write).map { |i| i.to_s * 14 }
+      ProcessResqueMessage.record_last_sync_times_for_barcodes generated_barcodes
+
+      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
+      # Expect truncation to have reduced hash size to 90% of max:
+      expect(ProcessResqueMessage.class_eval('@@sync_times').keys.size).to eq(9)
+
+      # Expect @@sync_times to only contain most recently written 9 barcodes:
+      kept_keys = ProcessResqueMessage.class_eval('@@sync_times').keys
+      expect(kept_keys).to contain_exactly("00000000000000", "11111111111111", "22222222222222", "33333333333333", "44444444444444", "55555555555555", "66666666666666", "77777777777777", "88888888888888")
+    end
+  end
+end


### PR DESCRIPTION
Adds basic de-duping to resque handler to avoid syncing any barcode that
appears to be redundant. This is done by maintaining a hash inside the
resque handler that associates barcodes with "last sync time". Any time
a new barcode is considered for syncing, the time the barcode was
written to SQS ("queued_at") is examined and compared to the "last sync
time" for that barcode. If it's determined that the same barcode was
actually already synced *after* the "queued_at" time, the barcode is
discarded. This addresses an issue where the resque queue grows so large
that multiple messages for a single barcode may enter the queue and take
so long to be processed that processing the first effectively makes
latter messages redundant (because processing later messages for that
same barcode would fetch the exact same data from the ItemService).

https://jira.nypl.org/browse/SCC-1344