### PR TITLE
Fix: sync-time lookup persisted to redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ If it is, it's persisted into Redis and deleted from SQS.
 1. `ruby ./dequeue_from_sqs.rb` and in another tab...`QUEUE=* rake resque:work`
 1.  Make sure the environment variable of `IS_DRY_RUN` is set correctly. If set to false, it will update the incomplete barcodes with SCSBXML in the assigned ReCap environment. If set to true, it will run the script without updating the barcodes.
 
+Ad hoc testing of resque workers in isolation can be achieved by:
+
+ - Open one terminal with `QUEUE=* rake resque:work`
+ - Open another terminal tab with `irb -r './boot'` and add arbitrary resque messages like:
+   - `Resque.enqueue(ProcessResqueMessage, { "user_email" => "user@example.com", "barcodes" => [ "1234" ], "action" => "update", "queued_at" => Time.now.to_f * 100 }.to_json)`
+
 #### Running From Docker Locally
 
 You can use docker and [`docker-compose`](https://docs.docker.com/compose/overview/) to run the app locally too.

--- a/lib/jobs/process_resque_message.rb
+++ b/lib/jobs/process_resque_message.rb
@@ -4,23 +4,27 @@ require 'json'
 
 # The Resque job that does all the actual handling of the message
 class ProcessResqueMessage
-  # Number of entries in @@sync_times hash we'll keep:
-  MAX_SYNC_TIMES_REMEMBERED = 100000
-
   @queue = :work_immediately
-  @@sync_times = {}
 
   # message a JSON string of the original SQS message body
   def self.perform(message)
-    Application.logger.info("Processing a message from SQS", original_message: message)
-    parsed_message = JSON.parse(message)
-    parsed_message['barcodes'] = remove_redundant_barcodes parsed_message
-    if parsed_message['barcodes'].empty?
-      Application.logger.debug("Skipping all barcodes in batch because each of them were written to SQS before the last sync for the same item", queued_at: parsed_message['queued_at'] )
-    else
-      resque_message_handler = ResqueMessageHandler.new(settings: Application.settings, message: parsed_message)
-      resque_message_handler.handle
-      record_last_sync_times_for_barcodes parsed_message['barcodes']
+    begin
+      Application.logger.info("Processing a message from SQS", original_message: message)
+      parsed_message = JSON.parse(message)
+
+      # Remove barcodes that would be redundant to process:
+      parsed_message['barcodes'] = remove_redundant_barcodes parsed_message
+
+      if parsed_message['barcodes'].empty?
+        Application.logger.debug("Skipping all barcodes in batch because each of them were written to SQS before the last sync for the same item", queued_at: parsed_message['queued_at'] )
+      else
+        resque_message_handler = ResqueMessageHandler.new(settings: Application.settings, message: parsed_message)
+        resque_message_handler.handle
+        record_last_sync_times_for_barcodes parsed_message['barcodes']
+      end
+    rescue Exception => e
+      Application.logger.error("ProcessResqueueMessage#perform: Error encountered: #{e.message}")
+      raise e
     end
   end
 
@@ -30,14 +34,15 @@ class ProcessResqueMessage
   # this tool synced them.
   def self.remove_redundant_barcodes (message)
     barcodes = message['barcodes']
-    queued_at = queued_at.to_i unless queued_at.nil?
+    queued_at = message['queued_at'].to_f unless message['queued_at'].nil?
 
     # In order to process a current very large backlock of redis events that do
     # not have the new 'queued_at' property saved, let's fall back on a
     # reasonable default value for 'queued_at'. The safest choice is to set this
     # to the maximum time it can possibly be, which is the time the 'queued_at'
     # started being saved.
-    queued_at = Time.new(2019, 5, 2, 10, 30, 00, '-04:00').to_i if queued_at.nil?
+    # (Mult. by 1000 to convert to ms to match unit of actual queued_at values)
+    queued_at = Time.new(2019, 5, 2, 10, 30, 00, '-04:00').to_f * 1000 if queued_at.nil?
 
     barcodes.select do |barcode|
       last_synced = last_sync_time barcode
@@ -49,35 +54,19 @@ class ProcessResqueMessage
     end
   end
 
-  # Return last sync time (in ms since epoch)
-  def self.last_sync_time (barcode)
-    @@sync_times[barcode]
-  end
-
   # For a given array of barcodes, records current time as "sync time"
   def self.record_last_sync_times_for_barcodes (barcodes)
-    current_time = Time.new.to_f * 1000
     barcodes.each do |barcode|
-      @@sync_times[barcode] = current_time
+      redis_sync_time_client.set_sync_time barcode
     end
-
-    truncate_sync_times
   end
 
-  # Reduce size of @sync_times hash when necessary
-  def self.truncate_sync_times
-    # If size of hash is below max, noop:
-    return if @@sync_times.keys.size <= MAX_SYNC_TIMES_REMEMBERED
+  # Return last sync time (in ms since epoch)
+  def self.last_sync_time (barcode)
+    self.redis_sync_time_client.get_sync_time barcode
+  end
 
-    # Determine number to remove.
-    # Let's reduce hash to 90% of max to limit how often we have to do this:
-    num_to_keep = 0.9 * MAX_SYNC_TIMES_REMEMBERED
-
-    @@sync_times = @@sync_times
-      .sort_by { |barcode, time| -time } # Sort barcodes by time DESC
-      .slice(0, num_to_keep) # Keep `num_to_keep` recent entries
-      .to_h
-
-    Application.logger.debug("GC: Reduced @@sync_times map to #{@@sync_times.keys.size}")
+  def self.redis_sync_time_client
+    @@redis_client ||= RedisSyncTimeClient.new
   end
 end

--- a/lib/redis_sync_time_client.rb
+++ b/lib/redis_sync_time_client.rb
@@ -1,0 +1,25 @@
+
+class RedisSyncTimeClient
+  KEY_EXPIRE = 60 * 60 * 24 * 7
+
+  def initialize
+    @client = Redis.new(url: "redis://#{Application.settings['redis_domain_and_port']}")
+    Application.logger.debug("RedisSyncTimeClient#initialize: Connecting to Redis: #{Application.settings['redis_domain_and_port']}")
+  end
+
+  def get_sync_time (barcode)
+    time = @client.get redis_sync_time_key(barcode)
+    time.to_f unless time.nil?
+  end
+
+  def set_sync_time (barcode, time = Time.new.to_f * 1000)
+    @client.set redis_sync_time_key(barcode), time.to_s
+    @client.expire redis_sync_time_key(barcode), KEY_EXPIRE
+  end
+
+  private
+
+  def redis_sync_time_key (barcode)
+    "sync-time-#{barcode}"
+  end
+end

--- a/lib/sqs_message_handler.rb
+++ b/lib/sqs_message_handler.rb
@@ -21,6 +21,8 @@ class SQSMessageHandler
       @logger.info "Message body: #{@message.body} with attributes #{@message.attributes} and user_attributes of #{@message.message_attributes}"
       if valid?
         # Copy SQS-receive-time into message as "queued_at"
+        # ApproximateFirstReceiveTimestamp is ms since epoch:
+        # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
         message_to_enqueue = JSON.parse(@message.body).merge({ queued_at: @message.attributes['ApproximateFirstReceiveTimestamp']}).to_json
         Resque.enqueue(ProcessResqueMessage, message_to_enqueue)
         @sqs_client.delete_message(queue_url: @settings['sqs_queue_url'], receipt_handle: @message.receipt_handle)

--- a/spec/process_resqueue_message_spec.rb
+++ b/spec/process_resqueue_message_spec.rb
@@ -2,13 +2,22 @@ require 'spec_helper'
 
 describe ProcessResqueMessage do
   before :each do
+    @redis_client_double = instance_double(Redis)
     # Let's pretend we've just synced these two barcodes:
-    ProcessResqueMessage.record_last_sync_times_for_barcodes ['012345', '67890']
+    allow(@redis_client_double).to receive(:get).with('sync-time-012345').and_return((Time.now.to_f * 1000).to_s)
+    allow(@redis_client_double).to receive(:get).with('sync-time-67890').and_return((Time.now.to_f * 1000).to_s)
+    allow(@redis_client_double).to receive(:get).with('sync-time-999').and_return(nil)
+
+    allow(Redis).to receive(:new).and_return(@redis_client_double)
+  end
+
+  after :each do
+    ProcessResqueMessage.class_variable_set("@@redis_client", nil)
   end
 
   describe "#record_last_sync_times_for_barcodes" do
     it "will record current times for an array of barcodes" do
-      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
+      # expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
     end
   end
 
@@ -22,7 +31,7 @@ describe ProcessResqueMessage do
     end
 
     it "will return nil barcode that hasn't been synced recently" do
-      expect(ProcessResqueMessage.last_sync_time('9999999999')).to be_nil
+      expect(ProcessResqueMessage.last_sync_time('999')).to be_nil
     end
   end
 
@@ -46,10 +55,10 @@ describe ProcessResqueMessage do
 
       # Because the new request to sync is older than the most recent sync,
       # running it would be redundant, so we expect it will have been removed:
-      barcodes = ProcessResqueMessage.remove_redundant_barcodes({ "barcodes" => ['012345', '999999999'], "queued_at" => old_queued_at })
+      barcodes = ProcessResqueMessage.remove_redundant_barcodes({ "barcodes" => ['012345', '999'], "queued_at" => old_queued_at })
       expect(barcodes).to be_a(Array)
       expect(barcodes.size).to eq(1)
-      expect(barcodes[0]).to eq('999999999')
+      expect(barcodes[0]).to eq('999')
     end
 
     it "will remove barcodes that were not added to redis with a queued_at" do
@@ -75,39 +84,6 @@ describe ProcessResqueMessage do
       barcodes = ProcessResqueMessage.remove_redundant_barcodes({ "barcodes" => ['012345'] })
       expect(barcodes).to be_a(Array)
       expect(barcodes.size).to eq(0)
-    end
-  end
-
-  describe "#truncate_sync_times" do
-    before do
-      ProcessResqueMessage.const_set 'MAX_SYNC_TIMES_REMEMBERED', 10
-    end
-
-    it "will not truncate @@sync_times if not necessary" do
-      # We've already written two barcodes in root `before` so writing
-      # this third barcode should produce a @@sync_times hash of length 3
-      ProcessResqueMessage.record_last_sync_times_for_barcodes ['999999999']
-
-      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
-      expect(ProcessResqueMessage.class_eval('@@sync_times').keys.size).to eq(3)
-    end
-
-    it "will truncate @@sync_times when max entries exceeded" do
-      # Get current size of hash after above tests:
-      existing_sync_times_size = ProcessResqueMessage.class_eval('@@sync_times').keys.size
-
-      # Write 10 new barcodes:
-      num_to_write = 11 - existing_sync_times_size
-      generated_barcodes = barcodes = (0..num_to_write).map { |i| i.to_s * 14 }
-      ProcessResqueMessage.record_last_sync_times_for_barcodes generated_barcodes
-
-      expect(ProcessResqueMessage.class_eval('@@sync_times')).to be_a(Object)
-      # Expect truncation to have reduced hash size to 90% of max:
-      expect(ProcessResqueMessage.class_eval('@@sync_times').keys.size).to eq(9)
-
-      # Expect @@sync_times to only contain most recently written 9 barcodes:
-      kept_keys = ProcessResqueMessage.class_eval('@@sync_times').keys
-      expect(kept_keys).to contain_exactly("00000000000000", "11111111111111", "22222222222222", "33333333333333", "44444444444444", "55555555555555", "66666666666666", "77777777777777", "88888888888888")
     end
   end
 end

--- a/spec/redis_sync_time_client_spec.rb
+++ b/spec/redis_sync_time_client_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe RedisSyncTimeClient  do
+  before :each do
+    @redis_client_double = instance_double(Redis)
+    allow(@redis_client_double).to receive(:get).with('sync-time-1234').and_return("1556900532788.04")
+    allow(@redis_client_double).to receive(:get).with('sync-time-never-synced-barcode').and_return(nil)
+
+    allow(Redis).to receive(:new).and_return(@redis_client_double)
+  end
+
+  describe "#get_sync_time" do
+    it "will return sync time as double" do
+      expect(RedisSyncTimeClient.new.get_sync_time('1234')).to eq(1556900532788.04)
+    end
+
+    it "will return nil if never synced" do
+      expect(RedisSyncTimeClient.new.get_sync_time('never-synced-barcode')).to be_nil
+    end
+  end
+
+  describe "#set_sync_time" do
+    it "will set sync time as string" do
+      expect(@redis_client_double).to receive(:set).with('sync-time-1234', '999.0')
+      expect(@redis_client_double).to receive(:expire).with('sync-time-1234', 60 * 60 * 24 * 7)
+      RedisSyncTimeClient.new.set_sync_time('1234', 999.0)
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug in the "sync-times" lookup, which was recently added
to ensure that barcodes are not synced more often than they reasonably
need to be (by comparing the date the sync request was queued with the
last time the barcode was synced). The lookup was previously stored as a
class variable. Apparently Resque rebuilds the environment *for each
message processed* by design, so class variables are wiped out. This fix
retains most of the original logic but uses Redis to persist the lookup.
Rather than store barcodes in a class variable hash, barcode sync times
are now persisted to redis (e.g. "sync-time-12345" =>
"1556900532788.04"). Redis keys are set to expire in 7 days.

This also fixes a couple simple & devastating bugs in the original implementation:
 - [queued_at was not being read correctly from the resque message](https://github.com/NYPL-discovery/scsb_item_updater/compare/persist-sync-times-to-redis?expand=1#diff-346082626a2a077b9794235df085f938R37)
 - [the fallback queued_at was computed in seconds rather than ms!](https://github.com/NYPL-discovery/scsb_item_updater/compare/persist-sync-times-to-redis?expand=1#diff-346082626a2a077b9794235df085f938R45)