### PR TITLE
Fix: do not skip incompletes although they appear unavailable

### DIFF
--- a/lib/resque_message_handler.rb
+++ b/lib/resque_message_handler.rb
@@ -125,22 +125,25 @@ class ResqueMessageHandler
   private
 
   # Given a hash relating barcodes to scsb items, returns a new hash consisting
-  # of only those items that are either:
-  #  1. Available
-  #  2. Incomplete
-  # These are the classes of records we're able to update.
+  # of only those items that we anticipate succeeding a SCSB update
   def get_barcodes_allowing_updates(barcode_mapping)
     barcode_mapping.select do |barcode, item|
-      item['availability'] == 'Available' || item['title'] == 'Dummy Title'
+      scsb_update_possible_for_item item
     end
   end
 
   # Get inverse of get_barcodes_allowing_updates
   def get_barcodes_disallowing_updates(barcode_mapping)
-    allowed = get_barcodes_allowing_updates barcode_mapping
-    # Build hash from difference obtained by deleting everything from
-    # `barcode_mapping` that exists in `allowed`:
-    Hash[*(barcode_mapping.to_a - allowed.to_a).flatten]
+    barcode_mapping.reject do |barcode, item|
+      scsb_update_possible_for_item item
+    end
+  end
+
+  # Returns true if given scsb item should succeed an update, i.e. it is either:
+  #  1. Available
+  #  2. Incomplete
+  def scsb_update_possible_for_item (item)
+    item['availability'] == 'Available' || item['title'] == 'Dummy Title'
   end
 
   def nypl_platform_client

--- a/spec/resque_message_handler_spec.rb
+++ b/spec/resque_message_handler_spec.rb
@@ -8,7 +8,7 @@ describe ResqueMessageHandler do
     allow(mock_error_mailer).to receive(:send_error_email)
   end
 
-  describe "#select_by_status" do
+  describe "#get_barcodes_allowing_updates" do
     let(:barcode_mapping) do
       {
         "33433003517483" => {
@@ -22,23 +22,28 @@ describe ResqueMessageHandler do
         "33433003517485" => {
           "barcode"=>"33433003517485",
           "availability"=>"Some Other Unrecognized Status"
+        },
+        "33433003517486" => {
+          "barcode"=>"33433003517486",
+          "availability"=>"Not Available",
+          "title"=>"Dummy Title"
         }
+
       }
     end
 
-
     it "will select available barcodes" do
-      mapping = ResqueMessageHandler.new.send :select_by_status, barcode_mapping, :available
+      mapping = ResqueMessageHandler.new.send :get_barcodes_allowing_updates, barcode_mapping
 
       expect(mapping).to be_a(Hash)
-      expect(mapping.keys).to contain_exactly('33433003517484')
+      expect(mapping.keys).to contain_exactly('33433003517484', '33433003517486')
 
       available_barcodes = mapping.map { |key, item| item['barcode'] }
-      expect(available_barcodes).to contain_exactly('33433003517484')
+      expect(available_barcodes).to contain_exactly('33433003517484', '33433003517486')
     end
 
     it "will select unavailable barcodes" do
-      mapping = ResqueMessageHandler.new.send :select_by_status, barcode_mapping, :unavailable
+      mapping = ResqueMessageHandler.new.send :get_barcodes_disallowing_updates, barcode_mapping
 
       expect(mapping.keys.size).to eq(2)
       expect(mapping.keys).to contain_exactly('33433003517483', '33433003517485')


### PR DESCRIPTION
Fixes bug recently introduced that causes updater to skip posting updated scsbxml for "Incomplete" records (because those records appear as "Not Available").