### PR TITLE
Remove call to refile

### DIFF
--- a/lib/resque_message_handler.rb
+++ b/lib/resque_message_handler.rb
@@ -102,11 +102,6 @@ class ResqueMessageHandler
       timer_start (subtask = "submit_collection_updater.update_scsb_items")
       submit_collection_updater.update_scsb_items
       timer_stop subtask
-
-      refiler = get_refiler(map_barcodes_for_refile(barcode_to_scsb_xml_mapping, submit_collection_updater.errors))
-      timer_start (subtask = "refiler.refile!")
-      refiler.refile!
-      timer_stop subtask
     end
 
     # Email requester:

--- a/lib/resque_message_handler.rb
+++ b/lib/resque_message_handler.rb
@@ -109,7 +109,6 @@ class ResqueMessageHandler
       mapper.errors,
       xml_fetcher ? xml_fetcher.errors : {},
       submit_collection_updater ? submit_collection_updater.errors : {},
-      refiler ? refiler.errors : {},
       non_availability_errors
     ])
 

--- a/spec/resque_message_handler_spec.rb
+++ b/spec/resque_message_handler_spec.rb
@@ -112,7 +112,7 @@ describe ResqueMessageHandler do
 
         # ErrorMailer is instantiated when there are no errors, but
         # error_hashes contains just empty hashes
-        expect(ErrorMailer).to receive(:new).with(hash_including(:error_hashes => [{}, {}, {}, {}, {}]))
+        expect(ErrorMailer).to receive(:new).with(hash_including(:error_hashes => [{}, {}, {}, {}]))
 
         handler.handle
       end


### PR DESCRIPTION
- Removes call to refile in `resque_message_handler#update`.
- Removes references to `refiler` in `update`
- Removes refile-related expectations in associated tests